### PR TITLE
Update 2018-10-27-ldap-server-setup.md

### DIFF
--- a/_posts/2018-10-27-ldap-server-setup.md
+++ b/_posts/2018-10-27-ldap-server-setup.md
@@ -232,10 +232,10 @@ userPassword: {CRYPT}$6$rounds=50000$b7166V2Na/kA9Hs$Q05k3jHtVI41pNohCkFQbfWsDXE
 
 dn: cn=test,ou=userPrivate,ou=groups,ou=example,dc=example,dc=com
 changetype: add
-objectClass: organizationalRole
 objectClass: posixGroup
 cn: test
 gidNumber: 10000
+memberUid: test
 ```
 
 To make this account an admin, we'll need to add it as a `roleOccupant` on


### PR DESCRIPTION
Around lines 234-240, it seems impossible for the group to be both a `posixGroup` and a `organizationalRole` because both are structurals.

I guess `posixGroup` should be kept since the goal is to build UPG.
I also added the corresponding `memberUid` so the user and the group are linked.